### PR TITLE
update: 鼠标右键释放来确认选择区域

### DIFF
--- a/src/RitsukageGif/Windows/RegionSelect.xaml.cs
+++ b/src/RitsukageGif/Windows/RegionSelect.xaml.cs
@@ -445,39 +445,6 @@ namespace RitsukageGif.Windows
                 _selectingStartPoint = point;
                 _selectingEndPoint = point;
             }
-
-            if (e.RightButton == MouseButtonState.Pressed)
-            {
-                if (_selecting)
-                {
-                    _selecting = false;
-                    _selected = true;
-                    if (_selectingMoved)
-                    {
-                        var position = e.GetPosition(this);
-                        var point = new DPoint((int)position.X + ScreenRectangle.X,
-                            (int)position.Y + ScreenRectangle.Y);
-                        point = GetPointWithPerception(point);
-                        _selectingEndPoint = point;
-                        _selectedStartPoint = _selectingStartPoint;
-                        _selectedEndPoint = _selectingEndPoint;
-                    }
-                    else
-                    {
-                        var view = ScreenInfo.MainScreen;
-                        if (view == null) return;
-                        _selectedStartPoint =
-                            view.ConvertFromScalePoint(
-                                new DPoint(PerceptionProgramArea.Left, PerceptionProgramArea.Top));
-                        _selectedEndPoint = view.ConvertFromScalePoint(new DPoint(PerceptionProgramArea.Right,
-                            PerceptionProgramArea.Bottom));
-                    }
-                }
-
-                _closing = true;
-                _confirm = true;
-                Close();
-            }
         }
 
         private void Window_MouseMove(object sender, MouseEventArgs e)
@@ -529,6 +496,40 @@ namespace RitsukageGif.Windows
                         UpdateSelectedRegion();
                     }
                 }
+                return;
+            }
+            if (e.RightButton == MouseButtonState.Released)
+            {
+                if (_selecting)
+                {
+                    _selecting = false;
+                    _selected = true;
+                    e.Handled = true;
+                    if (_selectingMoved)
+                    {
+                        var position = e.GetPosition(this);
+                        var point = new DPoint((int)position.X + ScreenRectangle.X,
+                            (int)position.Y + ScreenRectangle.Y);
+                        point = GetPointWithPerception(point);
+                        _selectingEndPoint = point;
+                        _selectedStartPoint = _selectingStartPoint;
+                        _selectedEndPoint = _selectingEndPoint;
+                    }
+                    else
+                    {
+                        var view = ScreenInfo.MainScreen;
+                        if (view == null) return;
+                        _selectedStartPoint =
+                            view.ConvertFromScalePoint(
+                                new DPoint(PerceptionProgramArea.Left, PerceptionProgramArea.Top));
+                        _selectedEndPoint = view.ConvertFromScalePoint(new DPoint(PerceptionProgramArea.Right,
+                            PerceptionProgramArea.Bottom));
+                    }
+                }
+
+                _closing = true;
+                _confirm = true;
+                Close();
             }
         }
 


### PR DESCRIPTION
把判定区域确认变成了右键释放


之前判定会有这样的情况：
鼠标右键按下=>窗口关闭（区域选择了）=>鼠标右键松开=>事件被传递到区域后面的窗口了=>我要录制的区域不干净了

